### PR TITLE
fix crash when data array count down

### DIFF
--- a/ELWaterFallLayout/Classes/ELWaterFlowLayout.swift
+++ b/ELWaterFallLayout/Classes/ELWaterFlowLayout.swift
@@ -96,6 +96,7 @@ open class ELWaterFlowLayout: UICollectionViewFlowLayout {
         super.prepare()
         resetLineWidth()
         resetLineHeight()
+        attrArr.removeAll()
 
         if let sectionCount = self.collectionView?.dataSource?.numberOfSections!(in: self.collectionView!) {
             for section in 0..<sectionCount{


### PR DESCRIPTION
fix crash when data decreased, e.g. 20 elements to 10, crash happen
like this :
 *** Assertion failure in -[UICollectionViewData validateLayoutInRect:], /BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit/UIKit-3600.9.1/UICollectionViewData.m:433
2017-08-20 00:15:20.859558+0800 ****[54202:8693277] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UICollectionView received layout attributes for a cell with an index path that does not exist: <NSIndexPath: 0x17023be80> {length = 2, path = 0 - 20}'